### PR TITLE
Build and clean to ./dist

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
 #
-rm -rf ./core
-rm -rf ./plugin
+rm -rf ./dist/
+#rm -rf ./core
+#rm -rf ./plugin
 
-rm -rf ./index.d.ts
-rm -rf ./index.js
-rm -rf ./index.js.map
+#rm -rf ./index.d.ts
+#rm -rf ./index.js
+#rm -rf ./index.js.map

--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
   "name": "budacode-ng2-scrollspy",
   "description": "Angular2 ScrollSpy Service",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author":  "Balazs Gallay <gallayb@gmail.com> (http://github.com/carathorys)",
   "dependencies": {
-    "immutable": "^3.7.6"
   },
   "devDependencies": {
     "angular2": "~2.0.0-beta.15",
@@ -12,6 +11,7 @@
     "cz-conventional-changelog": "~1.1.5",
     "es6-shim": "^0.35.0",
     "jasmine-core": "~2.4.1",
+    "immutable": "^3.7.6",
     "karma": "~0.13.21",
     "karma-chrome-launcher": "~0.2.2",
     "karma-firefox-launcher": "~0.1.7",
@@ -37,7 +37,6 @@
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "main": "./dist",
-  "typings": "./dist",
   "repository": {
     "type": "git",
     "url": "https://github.com/budacode/ng2-scrollspy.git"

--- a/package.json
+++ b/package.json
@@ -1,14 +1,15 @@
 {
-  "name": "ng2-scrollspy",
+  "name": "budacode-ng2-scrollspy",
   "description": "Angular2 ScrollSpy Service",
-  "author": "João Ribeiro <jonnybgod@gmail.com> (http://github.com/JonnyBGod)",
-  "dependencies": {},
+  "author":  "Balazs Gallay <gallayb@gmail.com> (http://github.com/carathorys)",
+  "dependencies": {
+    "immutable": "^3.7.6"
+  },
   "devDependencies": {
     "angular2": "~2.0.0-beta.15",
     "commitizen": "~2.7.2",
     "cz-conventional-changelog": "~1.1.5",
     "es6-shim": "^0.35.0",
-    "immutable": "^3.7.6",
     "jasmine-core": "~2.4.1",
     "karma": "~0.13.21",
     "karma-chrome-launcher": "~0.2.2",
@@ -35,7 +36,7 @@
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "main": "./dist",
-  "typings": "./",
+  "typings": "./dist",
   "repository": {
     "type": "git",
     "url": "https://github.com/budacode/ng2-scrollspy.git"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "João Ribeiro <jonnybgod@gmail.com> (http://github.com/JonnyBGod)",
   "dependencies": {},
   "devDependencies": {
-    "angular2": "~2.0.0-beta.12",
+    "angular2": "~2.0.0-beta.15",
     "commitizen": "~2.7.2",
     "cz-conventional-changelog": "~1.1.5",
     "es6-shim": "^0.35.0",
@@ -31,14 +31,14 @@
     "lint": "./node_modules/.bin/tslint ./src/*.ts ./src/**/*.ts",
     "test": "karma start",
     "commit": "git cz",
-    "prepublish": "./clean.sh && ./node_modules/.bin/typings install && tsc --outDir ./",
+    "prepublish": "./clean.sh && ./node_modules/.bin/typings install && tsc --removeComments --outDir ./dist",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
-  "main": "./",
+  "main": "./dist",
   "typings": "./",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jonnybgod/ng2-scrollspy.git"
+    "url": "https://github.com/budacode/ng2-scrollspy.git"
   },
   "keywords": [
     "angular2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "budacode-ng2-scrollspy",
   "description": "Angular2 ScrollSpy Service",
+  "version": "0.0.1",
   "author":  "Balazs Gallay <gallayb@gmail.com> (http://github.com/carathorys)",
   "dependencies": {
     "immutable": "^3.7.6"


### PR DESCRIPTION
Hi! 
I've run into a problem with your ng-scrollspy, and fixed it, for webpack. 
What the problem was: 
- when webpack tried to compile your index.js, it found a `///<reference path='./../../node_modules/immutable/dist/immutable.d.ts'/>` in the source, which can't be resolved
- my compile has failed - this plugin is unusable with webpack. 

What i've made: 
I've modified the package json for publish the compiled source files into `./dist`, and the clean.sh removes only that folder. 
The tsc got a new parameter: `--removeComments` for remove the `///<reference....` from the compiled files

ps.: this pull request doesn't contains any new version in the dist folder! 

Regards:
B
