### PR TITLE
fix(core): change 'OpaqueToken' to 'InjectionToken'

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import {
   ModuleWithProviders,
   Inject,
   Optional,
-  OpaqueToken,
+  InjectionToken,
   SkipSelf
 } from '@angular/core';
 
@@ -18,7 +18,7 @@ export * from './core/window.directive';
 export * from './core/element.directive';
 export * from './plugin/index.service';
 
-export const NG2SCROLLSPY_FORROOT_GUARD = new OpaqueToken('NG2SCROLLSPY_FORROOT_GUARD');
+export const NG2SCROLLSPY_FORROOT_GUARD = new InjectionToken('NG2SCROLLSPY_FORROOT_GUARD');
 export function provideForRootGuard(scrollSpyService: ScrollSpyService): any {
   if (scrollSpyService) {
     throw new Error(


### PR DESCRIPTION
## Adapt to Angular 5.0
BREAKING CHANGE: `OpaqueToken` has been removed as it was deprecated since v4. Use `InjectionToken` instead.

see [#18971](https://github.com/angular/angular/pull/18971)